### PR TITLE
feat: add contract deployment script and load the contract data from …

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,11 +1,33 @@
 const hre = require("hardhat")
+const { ethers } = require("hardhat")
 
 const tokens = (n) => {
   return ethers.utils.parseUnits(n.toString(), 'ether')
 }
 
 async function main() {
+  // Setup accounts & variables
+  const [deployer] = await ethers.getSigners()
+  const NAME = "Dappcord"
+  const SYMBOL = "DC"
 
+  // Deploy contract
+  const Dappcord = await ethers.getContractFactory("Dappcord")
+  const dappcord = await Dappcord.deploy(NAME, SYMBOL)
+  await dappcord.deployed()
+
+  console.log(`Deployed Dappcord Contract at: ${dappcord.address}\n`)
+
+  // Create 3 Channels
+  const CHANNEL_NAMES = ["general", "intro", "jobs"]
+  const COSTS = [tokens(1), tokens(0), tokens(0.25)]
+
+  for (var i = 0; i < 3; i++) {
+    const transaction = await dappcord.connect(deployer).createChannel(CHANNEL_NAMES[i], COSTS[i])
+    await transaction.wait()
+
+    console.log(`Created text channel #${CHANNEL_NAMES[i]}`)
+  }
 }
 
 main().catch((error) => {

--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,38 @@ const socket = io('ws://localhost:3030');
 
 function App() {
 
+  const [provider, setProvider] = useState(null)
+  const [dappcord, setDappcord] = useState(null)
+  const [channels, setChannels] = useState([])
+
+  const loadBlockchainData = async () => {
+    const provider = new ethers.providers.Web3Provider(window.ethereum)
+    setProvider(provider)
+
+    const network = await provider.getNetwork()
+    const dappcord = new ethers.Contract(config[network.chainId].Dappcord.address, Dappcord, provider)
+    setDappcord(dappcord)
+
+    const totalChannels = await dappcord.totalChannels()
+    const channels = []
+
+    for (var i = 1; i <= totalChannels; i++) {
+      const channel = await dappcord.getChannel(i)
+      channels.push(channel)
+    }
+
+    setChannels(channels)
+
+    window.ethereum.on('accountsChanged', async () => {
+      window.location.reload()
+    })
+  }
+
+  useEffect(() => {
+    loadBlockchainData()
+  }, [])
+
+
   return (
     <div>
       <h1 style={{ textAlign: "center", padding: "15px" }}>Welcome to Dappcord</h1>
@@ -31,3 +63,4 @@ function App() {
 }
 
 export default App;
+


### PR DESCRIPTION
## Issue
In the case of the `Dappcord` application, there wasn’t a full deployment script, and there also a lack of integration of the frontend with the blockchain. As a result of the script being empty, there wasn’t a contract deployed to any network. Furthermore, there also wasn’t any way on the frontend to interface with MetaMask, and there also wasn’t any way to load the contract or fetch any channel information from the blockchain, which made the application completely non-functional.  

## Solution
A full deployment script that deploys the Dappcord contract with the title “Dappcord” and the symbol “DC” was created, and it also sets up three channels: “general” (costs 1 ETH), “intro” (no cost), and “jobs” (costs 0.25 ETH). Moreover, I added blockchain functionality to the App component of the frontend, which integrates with MetaMask to fetch the contract, provisioned with the network parameters, retrieves all channels, and implements on account switch handler, which auto refreshes the page.

## Specific Requirements  
The deployment script should deploy the `Dappcord` contract and create exactly three channels with the specified names and costs. The frontend should initialize on component mount by creating a Web3Provider from `window.ethereum` , getting the network chainId in order to fetch the correct contract address from config, instantiating the contract, and getting all channels from totalChannels by iterating and storing them in state. Account change detection should cause a full page reload. For the time being, focus on these core functionalities; do not implement any other functionalities than the ones listed above, as they will be implemented later.

